### PR TITLE
refactor-label

### DIFF
--- a/components/atoms/Label/Label.tsx
+++ b/components/atoms/Label/Label.tsx
@@ -2,55 +2,45 @@ import classNames from 'classnames';
 import { View } from 'components/atoms/View';
 import { Text } from 'components/atoms/Text';
 
-interface IfLabelProps {
-  text?: React.ReactNode;
-  color?: 'primary' | 'secondary' | 'tetriary' | 'success' | 'danger';
+interface LabelProps {
+  text: string;
   textAlign?: 'left' | 'center' | 'right' | 'justify' | 'start' | 'end';
   textUppercase?: boolean;
+  primary?: boolean;
+  secondary?: boolean;
+  tetriary?: boolean;
+  success?: boolean;
+  danger?: boolean;
 }
 
 export const Label = ({
-  text = '',
-  color = 'primary',
-  textAlign = 'left',
+  text,
+  textAlign = 'center',
   textUppercase = false,
-}: IfLabelProps) => {
-  const getTextColor = (color: IfLabelProps['color']) => {
-    switch (color) {
-      case 'secondary':
-        return 'text-text-2';
-      case 'tetriary':
-        return 'text-text-3';
-      case 'success':
-      case 'danger':
-      case 'primary':
-      default:
-        return 'text-text-1';
-    }
-  };
-
-  const getBgColor = (color: IfLabelProps['color']) => {
-    switch (color) {
-      case 'secondary':
-        return 'bg-surface-2';
-      case 'tetriary':
-        return 'bg-surface-3';
-      case 'success':
-      case 'danger':
-      case 'primary':
-      default:
-        return 'bg-surface-1';
-    }
-  };
-
+  primary = true,
+  secondary,
+  tetriary,
+  success,
+  danger,
+}: LabelProps) => {
   return (
     <View
-      className={classNames('p-3 rounded-full', `${getBgColor(color)}`, {
-        uppercase: textUppercase,
+      className={classNames('p-3 rounded-full', {
+        'bg-surface-1': primary || success || danger,
+        'bg-surface-2': secondary,
+        'bg-surface-3': tetriary,
       })}
     >
       {text && (
-        <Text styles={`text-${textAlign} ${getTextColor(color)}`}>{text}</Text>
+        <Text
+          styles={`text-${textAlign}`}
+          primary={primary || success || danger}
+          secondary={secondary}
+          tetriary={tetriary}
+          uppercase={textUppercase}
+        >
+          {text}
+        </Text>
       )}
     </View>
   );

--- a/components/atoms/Text/Text.tsx
+++ b/components/atoms/Text/Text.tsx
@@ -11,6 +11,7 @@ interface TextProps {
   uppercase?: boolean;
   primary?: boolean;
   secondary?: boolean;
+  tetriary?: boolean;
   bold?: boolean;
 }
 
@@ -21,20 +22,22 @@ export const Text = ({
   styles,
   fontSize = 'regular',
   uppercase,
-  primary,
+  primary = true,
   secondary,
+  tetriary,
   bold,
 }: TextProps) => {
   return (
     <StyledText
       className={classnames(
-        `font-titilium-semibold text-text-1`,
+        `font-titilium-semibold`,
         styles,
         FontSizes[fontSize],
         {
           uppercase: uppercase,
-          'text-text-2': primary,
-          'text-text-3': secondary,
+          'text-text-1': primary,
+          'text-text-2': secondary,
+          'text-text-3': tetriary,
           'font-titilium-bold': bold,
         },
       )}

--- a/components/screens/Settings/Settings.tsx
+++ b/components/screens/Settings/Settings.tsx
@@ -9,12 +9,7 @@ export const Settings = () => {
         Settings
       </Text>
       <Input placeholder="elo" suffix="kg" />
-      <Label
-        text="test"
-        color="secondary"
-        textAlign="center"
-        textUppercase
-      ></Label>
+      <Label text="test" textAlign="center" textUppercase />
     </>
   );
 };


### PR DESCRIPTION
Co myślisz o takim rozwiązaniu ? Czy nie wydaje się bardziej czytelne ? 
Text posiadał już propsy primary, secondary itd do kolorów więc wybierasz, który tak naprawdę ma polecieć tam. 
Jak dla mnie jest to dużo bardziej czytelniejsze od dodatkowych funkcji, nie krytykuje Twojej wersji, ale ten native się mi wtedy sypał i jutro zrobię test jeszcze. Starałem się poprzeglądać dobre praktyki z Tailwindem i ta wydaje się być najczęściej używana, tym bardziej w SB tak też korzystalismy z takich conditionali, pamiętaj, że zawsze można dodać propsa `style` i z zewnątrz dodawać customowe style :) Jak czujesz wkurwa to spokojnie, w SB mieliśmy gościa co przerabiał nam całe komponenty od 0 bo mu się nie podobało, w tym ludzi którzy pracowali na React ponad 4 lata xd